### PR TITLE
New yaml definitions for Samsung MIM-H04 controller via Smarthings cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ At this moment it is configured to work with:
 * Samsung AC units available at port 8888 (new generation, REST API)
 * Samsung AC units available at port 2878 (old generation, socket communication)
 * Samsung MIM-H03 controller (REST API, port 8888)
+* Samsung MIM-H04 controller via Smarthings cloud (REST API)
 
 Support for any unit working with REST API can be easily added via YAML configuration file.
 
@@ -42,6 +43,23 @@ https://github.com/SebuZet/samsungrac
           cert: 'ac14k_m.pem' #set as '' to skip certificate verification
           mac: 'AB:cd:EF:gh:IJ'
           poll: True
+        ```
+    * For Samsung EHS Mono Quiet heat pump with MIM-H04EN controller connected to Smartthings:
+        ```
+        # hot water controller
+        - platform: climate_ip
+          name: Samsung EHS DHW
+          config_file: /config/custom_components/climate_ip/samsung_smartthings_dhw.yaml
+          ip_address: api.smartthings.com
+          device_id: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+          token: !secret smartthings_token
+        # heating controller
+        - platform: climate_ip
+          name: Samsung EHS Heating
+          config_file: /config/custom_components/climate_ip/samsung_smartthings_hvac.yaml
+          ip_address: api.smartthings.com
+          device_id: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+          token: !secret smartthings_token
         ```
 ## Configuration
 1. Configuration parameters:

--- a/custom_components/climate_ip/connection_request.py
+++ b/custom_components/climate_ip/connection_request.py
@@ -25,7 +25,8 @@ class SamsungHTTPAdapter(HTTPAdapter):
         super().__init__(*args, **kwargs)
 
     def init_poolmanager(self, *args, **kwargs):
-        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+        ssl_context = ssl.create_default_context()
+        ssl_context.check_hostname = False
         ssl_context.set_ciphers("ALL:@SECLEVEL=0")
         kwargs["ssl_context"] = ssl_context
         return super().init_poolmanager(*args, **kwargs)

--- a/custom_components/climate_ip/samsung_smartthings_dhw.yaml
+++ b/custom_components/climate_ip/samsung_smartthings_dhw.yaml
@@ -1,0 +1,67 @@
+# Configuration for Samsung EHS Mono Quiet heat pump with MIM-H04EN controller connected to smartthings cloud
+# this definition is for DHW (aka Domestic Hot Water) function
+device:
+  name: samsung_smartthing_dhw
+  poll: true
+  update_delay: 30
+  unique_id:
+    type: string
+    status_template: __DEVICE_ID__/dhw
+  connection:
+    type: request
+    params:
+      url: 'https://__CLIMATE_IP_HOST__/v1/devices/__DEVICE_ID__/commands'
+      method: POST
+      verify: True
+      headers:
+        authorization: 'Bearer __CLIMATE_IP_TOKEN__'
+        content_type: 'application/json; charset=utf-8'
+  status:
+    type: 'json_status'
+    connection:
+      params:
+        method: GET
+        url: 'https://__CLIMATE_IP_HOST__/v1/devices/__DEVICE_ID__/status/'
+    status_template: '{{ "OK" if (device_state.components.main.temperatureMeasurement.temperature.value | float) > -100 else "ERROR" }}'
+  operations:
+    hvac: # hvac_mode
+      type: modes
+      values:
+        heat:
+          value: 'on'
+        'off': # must be quoted otherwise is interpreted as false
+          value: 'off'
+      status_template: '{{ "heat" if device_state.components.main.switch.switch.value == "on" else "off" }}'
+      connection_template: '{ "json": { "commands": [ {"component": "main", "capability": "switch", "command": "{{value}}" } ] } }'
+    preset: # preset_mode
+      type: modes
+      values:
+        Eco: {}
+        Std: {}
+        Force: {}
+      status_template: '{{ device_state.components.main.airConditionerMode.airConditionerMode.value | capitalize }}'
+      connection_template: '{ "json": { "commands": [ {"component": "main", "capability": "switch", "command": "off" }, { "component": "main", "capability": "airConditionerMode", "command": "setAirConditionerMode", "arguments": [ "{{value|lower}}" ] } ] } }'
+    power:
+      type: switch
+      values:
+        'on': {}
+        'off': {}
+      status_template: '{{ device_state.components.main.switch.switch.value }}'
+      connection_template: '{ "json": { "commands": [ {"component": "main", "capability": "switch", "command": "{{value}}" } ] } }'
+    temperature:
+      type: number
+      status_template: '{{ device_state.components.main.thermostatCoolingSetpoint.coolingSetpoint.value | float }}'
+      connection_template: '{ "json": { "commands": [ {"component": "main", "capability": "switch", "command": "off" }, { "component": "main", "capability": "thermostatCoolingSetpoint", "command": "setCoolingSetpoint", "arguments": [ {{value | int}} ] } ] } }'
+  attributes:
+    current_temperature:
+      type: number
+      status_template: '{{ device_state.components.main.temperatureMeasurement.temperature.value | float }}'
+    target_temperature:
+      type: number
+      status_template: '{{ device_state.components.main.thermostatCoolingSetpoint.coolingSetpoint.value | float }}'
+    min_temp:
+      type: number
+      status_template: '{{ device_state.components.main["custom.thermostatSetpointControl"].minimumSetpoint.value | float }}'
+    max_temp:
+      type: number
+      status_template: '{{ device_state.components.main["custom.thermostatSetpointControl"].maximumSetpoint.value | float }}'

--- a/custom_components/climate_ip/samsung_smartthings_hvac.yaml
+++ b/custom_components/climate_ip/samsung_smartthings_hvac.yaml
@@ -1,0 +1,79 @@
+# Configuration for Samsung EHS Mono Quiet heat pump with MIM-H04EN controller connected to smartthings cloud
+# this definition is for Heating/Cooling function
+device:
+  name: samsung_smartthings_hvac
+  poll: true
+  update_delay: 30
+  unique_id:
+    type: string
+    status_template: __DEVICE_ID__/hvac
+  connection:
+    type: request
+    params:
+      url: 'https://__CLIMATE_IP_HOST__/v1/devices/__DEVICE_ID__/commands'
+      method: POST
+      verify: True
+      headers:
+        authorization: 'Bearer __CLIMATE_IP_TOKEN__'
+        content_type: 'application/json; charset=utf-8'
+  status:
+    type: 'json_status'
+    connection:
+      params:
+        method: GET
+        url: 'https://__CLIMATE_IP_HOST__/v1/devices/__DEVICE_ID__/status/'
+    status_template: '{{ "OK" if (device_state.components.INDOOR.temperatureMeasurement.temperature.value | float) > -100 else "ERROR" }}'
+  operations:
+    hvac: # hvac_mode
+      type: modes
+      values:
+        auto: {}
+        cool: {}
+        heat: {}
+        'off': {} # must be quoted otherwise is interpreted as false
+      status_template: '{{ device_state.components.INDOOR.airConditionerMode.airConditionerMode.value if device_state.components.INDOOR.switch.switch.value == "on" else "off" }}'
+      connection_template: >-
+          {% if value == "off" %}
+          { "json": {"commands": [{"component": "INDOOR", "capability": "switch", "command": "off" }]} }
+          {% else %}
+          { "json": {"commands": [{"component": "INDOOR", "capability": "switch", "command": "on" }, {"component": "INDOOR", "capability": "airConditionerMode", "command": "setAirConditionerMode", "arguments": ["{{value}}"]}]} }
+          {% endif %}
+    power:
+      type: switch
+      values:
+        'on': {}
+        'off': {}
+      status_template: '{{ device_state.components.INDOOR.switch.switch.value }}'
+      connection_template: '{ "json": { "commands": [ {"component": "INDOOR", "capability": "switch", "command": "{{value}}" } ] } }'
+    temperature:
+      type: number
+      status_template: '{{ 50 if device_state.components.INDOOR.airConditionerMode.airConditionerMode.value == "auto" else device_state.components.INDOOR.thermostatCoolingSetpoint.coolingSetpoint.value | float }}'
+      connection_template: '{ "json": { "commands": [ {"component": "INDOOR", "capability": "switch", "command": "off" }, { "component": "INDOOR", "capability": "thermostatCoolingSetpoint", "command": "setCoolingSetpoint", "arguments": [ {{value | int}} ] } ] } }'
+  attributes:
+    current_temperature:
+      type: number
+      status_template: '{{ device_state.components.INDOOR.temperatureMeasurement.temperature.value | float }}'
+    target_temperature:
+      type: number
+      status_template: '{{ device_state.components.INDOOR.thermostatCoolingSetpoint.coolingSetpoint.value | float }}'
+    min_temp:
+      type: number
+      status_template: '{{ device_state.components.INDOOR["custom.thermostatSetpointControl"].minimumSetpoint.value | float if (device_state.components.INDOOR["custom.thermostatSetpointControl"].minimumSetpoint.value | float) > 0 else 25 }}'
+    max_temp:
+      type: number
+      status_template: '{{ device_state.components.INDOOR["custom.thermostatSetpointControl"].maximumSetpoint.value | float if (device_state.components.INDOOR["custom.thermostatSetpointControl"].maximumSetpoint.value | float) > 0 else 65}}'
+    outing_mode:
+      type: string
+      status_template: '{{ device_state.components.main["custom.outingMode"].outingMode.value }}'
+    consumption:
+      type: number
+      status_template: '{{ device_state.components.main.powerConsumptionReport.powerConsumption.value.power | float * 1000}}'
+    energy:
+      type: number
+      status_template: '{{ device_state.components.main.powerConsumptionReport.powerConsumption.value.energy | float / 1000 }}'
+    mode:
+      type: string
+      status_template: '{{ device_state.components.INDOOR.airConditionerMode.airConditionerMode.value | capitalize }}'
+    fsv_settings:
+      type: string
+      status_template: '{{ device_state.components.main["samsungce.ehsFsvSettings"].fsvSettings.value }}'


### PR DESCRIPTION
New Samsung MIM-H04 controller unfortunately does not expose any of the previously used ports/protocols.
So it can't be controlled locally, currently the only way is to connect it to Smartthings cloud.
Here are definitions which allow to control the device via smartthings API.